### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - Get the binary from https://github.com/onmyway133/GifCapture/releases
 
 #### Brew Cask
-- Run `brew cask install gifcapture`
+- Run `brew install --cask gifcapture`
 
 ## How to use
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524